### PR TITLE
Feat: Close/Disable menu on death, support resource rename, add money type

### DIFF
--- a/Client/Client.lua
+++ b/Client/Client.lua
@@ -71,20 +71,6 @@ CreateThread(function()
     end
 end)
 
-CreateThread(function()
-    local sleep = 1000
-    while true do
-        if open then
-            if not CanOpenPauseMenu() then
-                SetNuiFocus(false, false)
-                DestroyCamera()
-            end
-            sleep = 500
-        end
-        Wait(sleep)
-    end
-end)
-
 RegisterNUICallback('exit', function(data, cb)
   SetNuiFocus(false, false)
   open = false

--- a/Client/Client.lua
+++ b/Client/Client.lua
@@ -11,9 +11,17 @@ end)
 
 RegisterKeyMapping('openSetting', 'Open Settings Menu', 'keyboard', 'ESCAPE')
 
+function CanOpenPauseMenu()
+    Player = QBCore.Functions.GetPlayerData()
+    if Player.metadata["isdead"] or Player.metadata["inlaststand"] then
+        return false
+    else
+        return true
+    end
+end
 
 function OpenPauseMenu()
-    if not open and not IsPauseMenuActive() then 
+    if not open and not IsPauseMenuActive() and CanOpenPauseMenu() then 
         SetNuiFocus(true,true)
         SendNUIMessage({
             action = 'show',
@@ -63,6 +71,20 @@ CreateThread(function()
     end
 end)
 
+CreateThread(function()
+    local sleep = 1000
+    while true do
+        if open then
+            if not CanOpenPauseMenu() then
+                SetNuiFocus(false, false)
+                DestroyCamera()
+            end
+            sleep = 500
+        end
+        Wait(sleep)
+    end
+end)
+
 RegisterNUICallback('exit', function(data, cb)
   SetNuiFocus(false, false)
   open = false
@@ -94,6 +116,10 @@ AddEventHandler('onResourceStart', function(resource)
     end
 end)
 
+AddEventHandler('baseevents:onPlayerDied', function()
+    SendNUIMessage({action = "closeMenu"})
+end)
+
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     LoadPlayerData()
 end)
@@ -110,4 +136,10 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
         key = "job", 
         value = PlayerJob.label.." - "..PlayerJob.grade.name
     })
+end)
+
+RegisterNetEvent('Roda_PauseMenu:CloseMenu', function(close)
+    if close then
+        SendNUIMessage({action = "closeMenu"})
+    end
 end)

--- a/Server/Server.lua
+++ b/Server/Server.lua
@@ -17,3 +17,19 @@ QBCore.Functions.CreateCallback("Roda_PauseMenu:GetOnlineJobs", function(src, cb
     table.sort(jobs, function(a, b)    return a.count > b.count end)
     cb(jobs)
 end)
+
+RegisterNetEvent('hospital:server:SetDeathStatus', function(isDead)
+    local src = source
+	local Player = QBCore.Functions.GetPlayer(src)
+	if Player then
+		TriggerClientEvent('Roda_PauseMenu:CloseMenu', src, isDead)
+	end
+end)
+
+RegisterNetEvent('hospital:server:SetLaststandStatus', function(inlaststand)
+    local src = source
+	local Player = QBCore.Functions.GetPlayer(src)
+	if Player then
+		TriggerClientEvent('Roda_PauseMenu:CloseMenu', src, inlaststand)
+	end
+end)

--- a/html/app.js
+++ b/html/app.js
@@ -1,3 +1,5 @@
+const resourceName = window.GetParentResourceName();
+
 window.addEventListener('message', function (event) {
   var v = event.data
 
@@ -44,7 +46,15 @@ function setValue(key, value) {
         duration: 2000,
         easing: 'swing',
         step: function (now) {
-          $this.text('$ ' + Math.ceil(now));
+          var prefix = '$ ';
+          if(key=='cash'){
+            prefix = 'Cash: $ ';
+          }else if(key=='bank'){
+            prefix = 'Bank: $ ';
+          }else if(key=='crypto'){
+            prefix = 'Crypto: $ ';
+          }
+          $this.text(prefix + Math.ceil(now));
         }
       });
     } else {
@@ -60,11 +70,11 @@ function ShowSettings() {
 
 $(function () {
   $('#settingsPe').click(function () {
-    $.post('https://Roda_PauseMenu/SendAction', JSON.stringify({ action: 'settings' }));
+    $.post(`https://${resourceName}/SendAction`, JSON.stringify({ action: 'settings' }));
     CloseAll()
   })
   $('#mapita').click(function () {
-    $.post('https://Roda_PauseMenu/SendAction', JSON.stringify({ action: 'map' }));
+    $.post(`https://${resourceName}/SendAction`, JSON.stringify({ action: 'map' }));
     CloseAll()
   })
   $('#resume').click(function () {
@@ -84,5 +94,5 @@ function CloseAll() {
   $(document).unbind("keyup", escapeHandler);
   $('.RemoveShit').remove()
   $('.container-fluid').hide(500)
-  $.post('https://Roda_PauseMenu/exit', JSON.stringify({}));
+  $.post(`https://${resourceName}/exit`, JSON.stringify({}));
 }

--- a/html/app.js
+++ b/html/app.js
@@ -23,6 +23,10 @@ window.addEventListener('message', function (event) {
     case 'updatePlayers':
       $('.footer h2').text(`Connected Players ${v.total}/${v.max}`)
       break;
+      
+    case 'closeMenu':
+      CloseAll()
+      break;
   }
 })
 


### PR DESCRIPTION
This PR will close the menu and/or disable it upon death or last stand. It listens for both the death event from baseevents and qb-ambulancejob, and triggers a new NUI event ('closeMenu').

I've added some accessibility additions for displaying Cash, Bank and Crypto (text next to the money).

Additionally, resource renaming is now supported via app.js.